### PR TITLE
Changed the order of dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3630,12 +3630,6 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
-    "node-http-server": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/node-http-server/-/node-http-server-8.1.2.tgz",
-      "integrity": "sha512-MB55WSzmWuk3nH1umA56IuTFbXdPRP2uYTlqFRMlYxUolvW7+SRXbvazCaqlstzTK41OM5385P5GPTHLqoLY1g==",
-      "dev": true
-    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3630,6 +3630,12 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-http-server": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/node-http-server/-/node-http-server-8.1.2.tgz",
+      "integrity": "sha512-MB55WSzmWuk3nH1umA56IuTFbXdPRP2uYTlqFRMlYxUolvW7+SRXbvazCaqlstzTK41OM5385P5GPTHLqoLY1g==",
+      "dev": true
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -36,11 +36,11 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "start-server-and-test": "^1.11.0",
     "jest": "^26.0.1",
     "jest-cli": "^26.0.1",
     "jest-puppeteer": "^4.4.0",
     "node-http-server": "^8.1.2",
-    "puppeteer": "^3.0.4",
-    "start-server-and-test": "^1.11.0"
+    "puppeteer": "^3.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "jest": "^26.0.1",
     "jest-cli": "^26.0.1",
     "jest-puppeteer": "^4.4.0",
+    "node-http-server": "^8.1.2",
     "puppeteer": "^3.0.4",
     "start-server-and-test": "^1.11.0"
   }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "jest": "^26.0.1",
     "jest-cli": "^26.0.1",
     "jest-puppeteer": "^4.4.0",
-    "node-http-server": "^8.1.2",
     "puppeteer": "^3.0.4"
   }
 }


### PR DESCRIPTION
This is required for windows environment. An Mac OS specific optional dependency (fsevents) was making npm throw a warning and some packages were not being installed after that... namingly the start-server-and-test package. But moving it to the top of the list fixes that.